### PR TITLE
Re-enable quay.io tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -44,9 +44,9 @@ function tmpf() {
 # Manifest that requires per-layer whiteouts.
 ./tosi -image gcr.io/google-samples/gb-frontend:v4 -saveconfig "$(tmpf)" -extractto "$(tmpd)"
 # Registry that does not support pings.
-#./tosi -image quay.io/quay/redis -saveconfig "$(tmpf)" -extractto "$(tmpd)"
+./tosi -image quay.io/quay/redis -saveconfig "$(tmpf)" -extractto "$(tmpd)"
 # Old-style deprecated URL parameter.
-#./tosi -url https://quay.io -image calico/cni:v3.4.0 -saveconfig "$(tmpf)" -extractto "$(tmpd)"
+./tosi -url https://quay.io -image calico/cni:v3.4.0 -saveconfig "$(tmpf)" -extractto "$(tmpd)"
 # A layer creates a file that overwrites a symlink from a previous layer.
 ./tosi -image gcr.io/google-containers/conformance:v1.17.3 -saveconfig "$(tmpf)" -extractto "$(tmpd)"
 # Create overlayfs.


### PR DESCRIPTION
These were disabled when quay.io had a long-running outage.