### PR TITLE
 Don't log command line arguments 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GIT_VERSION=$(shell git describe --dirty || echo dev)
 
-LDFLAGS=-ldflags "-X main.VERSION=$(GIT_VERSION)"
+LDFLAGS=-ldflags "-X main.Version=$(GIT_VERSION)"
 
 BINARIES=tosi
 

--- a/cmd/tosi/tosi.go
+++ b/cmd/tosi/tosi.go
@@ -34,7 +34,7 @@ const (
 )
 
 var (
-	VERSION = "unknown"
+	Version = "unknown"
 )
 
 type ImageConfig struct {
@@ -63,11 +63,11 @@ func main() {
 	}
 
 	if *version {
-		fmt.Printf("%s version %s\n", progname, VERSION)
+		fmt.Printf("%s version %s\n", progname, Version)
 		os.Exit(0)
 	}
 
-	glog.Infof("%s version: %s", progname, VERSION)
+	glog.Infof("%s version: %s", progname, Version)
 
 	if *image == "" {
 		glog.Fatalf("Please specify image to pull")

--- a/cmd/tosi/tosi.go
+++ b/cmd/tosi/tosi.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/elotl/tosi/pkg/registryclient"
@@ -56,12 +57,17 @@ func main() {
 	flag.Parse()
 	flag.Lookup("logtostderr").Value.Set("true")
 
+	progname := "tosi"
+	if len(os.Args) > 0 {
+		progname = filepath.Base(os.Args[0])
+	}
+
 	if *version {
-		fmt.Printf("Tosi version %s\n", VERSION)
+		fmt.Printf("%s version %s\n", progname, VERSION)
 		os.Exit(0)
 	}
 
-	glog.Infof("Tosi version: %s parameters: %v", VERSION, os.Args)
+	glog.Infof("%s version: %s", progname, VERSION)
 
 	if *image == "" {
 		glog.Fatalf("Please specify image to pull")


### PR DESCRIPTION
Changed logs to not include command line parameters, since they might include a registry password.